### PR TITLE
Adds the ability to attach flags to a pflag.FlagSet if not using cobra

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/pkg/errors v0.8.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/cobra v0.0.3
-	github.com/spf13/pflag v1.0.3 // indirect
+	github.com/spf13/pflag v1.0.3
 	github.com/stretchr/testify v1.2.2 // indirect
 	go.uber.org/atomic v1.3.2 // indirect
 	go.uber.org/multierr v1.1.0 // indirect

--- a/options.go
+++ b/options.go
@@ -316,11 +316,8 @@ func (o *Options) AttachFlags(cmd *cobra.Command) {
 
 // AttachToFlagSet attaches a set of pflags to the provided FlagSet and returns the FlagSet.
 //
-// If FlagSet is not provided, a new one will be created and returned.
+// FlagSet should be provided explicitly, failure to do so will result in a panic.
 func (o *Options) AttachToFlagSet(fs *pflag.FlagSet) *pflag.FlagSet {
-	if fs == nil {
-		fs = pflag.NewFlagSet("Log Options", pflag.ExitOnError)
-	}
 	fs.StringArrayVar(&o.OutputPaths, "log-target", o.OutputPaths,
 		"The set of paths where to output the log. This can be any path as well as the special values stdout and stderr")
 

--- a/options.go
+++ b/options.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 const (
@@ -310,22 +311,32 @@ func convertScopedLevel(sl string) (string, Level, error) {
 // the necessary set of flags to expose a CLI to let the user control all
 // logging options.
 func (o *Options) AttachFlags(cmd *cobra.Command) {
-	cmd.PersistentFlags().StringArrayVar(&o.OutputPaths, "log-target", o.OutputPaths,
+	_ = o.AttachToFlagSet(cmd.PersistentFlags())
+}
+
+// AttachToFlagSet attaches a set of pflags to the provided FlagSet and returns the FlagSet.
+//
+// If FlagSet is not provided, a new one will be created and returned.
+func (o *Options) AttachToFlagSet(fs *pflag.FlagSet) *pflag.FlagSet {
+	if fs == nil {
+		fs = pflag.NewFlagSet("Log Options", pflag.ExitOnError)
+	}
+	fs.StringArrayVar(&o.OutputPaths, "log-target", o.OutputPaths,
 		"The set of paths where to output the log. This can be any path as well as the special values stdout and stderr")
 
-	cmd.PersistentFlags().StringVar(&o.RotateOutputPath, "log-rotate", o.RotateOutputPath,
+	fs.StringVar(&o.RotateOutputPath, "log-rotate", o.RotateOutputPath,
 		"The path for the optional rotating log file")
 
-	cmd.PersistentFlags().IntVar(&o.RotationMaxAge, "log-rotate-max-age", o.RotationMaxAge,
+	fs.IntVar(&o.RotationMaxAge, "log-rotate-max-age", o.RotationMaxAge,
 		"The maximum age in days of a log file beyond which the file is rotated (0 indicates no limit)")
 
-	cmd.PersistentFlags().IntVar(&o.RotationMaxSize, "log-rotate-max-size", o.RotationMaxSize,
+	fs.IntVar(&o.RotationMaxSize, "log-rotate-max-size", o.RotationMaxSize,
 		"The maximum size in megabytes of a log file beyond which the file is rotated")
 
-	cmd.PersistentFlags().IntVar(&o.RotationMaxBackups, "log-rotate-max-backups", o.RotationMaxBackups,
+	fs.IntVar(&o.RotationMaxBackups, "log-rotate-max-backups", o.RotationMaxBackups,
 		"The maximum number of log file backups to keep before older files are deleted (0 indicates no limit)")
 
-	cmd.PersistentFlags().BoolVar(&o.JSONEncoding, "log-as-json", o.JSONEncoding,
+	fs.BoolVar(&o.JSONEncoding, "log-as-json", o.JSONEncoding,
 		"Whether to format output as JSON or in plain console-friendly format")
 
 	allScopes := Scopes()
@@ -337,7 +348,7 @@ func (o *Options) AttachFlags(cmd *cobra.Command) {
 		sort.Strings(keys)
 		s := strings.Join(keys, ", ")
 
-		cmd.PersistentFlags().StringVar(&o.outputLevels, "log-output-level", o.outputLevels,
+		fs.StringVar(&o.outputLevels, "log-output-level", o.outputLevels,
 			fmt.Sprintf("Comma-separated minimum per-scope logging level of messages to output, in the form of "+
 				"<scope>:<level>,<scope>:<level>,... where scope can be one of [%s] and level can be one of [%s, %s, %s, %s, %s]",
 				s,
@@ -347,7 +358,7 @@ func (o *Options) AttachFlags(cmd *cobra.Command) {
 				levelToString[ErrorLevel],
 				levelToString[NoneLevel]))
 
-		cmd.PersistentFlags().StringVar(&o.stackTraceLevels, "log-stacktrace-level", o.stackTraceLevels,
+		fs.StringVar(&o.stackTraceLevels, "log-stacktrace-level", o.stackTraceLevels,
 			fmt.Sprintf("Comma-separated minimum per-scope logging level at which stack traces are captured, in the form of "+
 				"<scope>:<level>,<scope:level>,... where scope can be one of [%s] and level can be one of [%s, %s, %s, %s, %s]",
 				s,
@@ -357,10 +368,10 @@ func (o *Options) AttachFlags(cmd *cobra.Command) {
 				levelToString[ErrorLevel],
 				levelToString[NoneLevel]))
 
-		cmd.PersistentFlags().StringVar(&o.logCallers, "log-caller", o.logCallers,
+		fs.StringVar(&o.logCallers, "log-caller", o.logCallers,
 			fmt.Sprintf("Comma-separated list of scopes for which to include caller information, scopes can be any of [%s]", s))
 	} else {
-		cmd.PersistentFlags().StringVar(&o.outputLevels, "log-output-level", o.outputLevels,
+		fs.StringVar(&o.outputLevels, "log-output-level", o.outputLevels,
 			fmt.Sprintf("The minimum logging level of messages to output,  can be one of [%s, %s, %s, %s, %s]",
 				levelToString[DebugLevel],
 				levelToString[InfoLevel],
@@ -368,7 +379,7 @@ func (o *Options) AttachFlags(cmd *cobra.Command) {
 				levelToString[ErrorLevel],
 				levelToString[NoneLevel]))
 
-		cmd.PersistentFlags().StringVar(&o.stackTraceLevels, "log-stacktrace-level", o.stackTraceLevels,
+		fs.StringVar(&o.stackTraceLevels, "log-stacktrace-level", o.stackTraceLevels,
 			fmt.Sprintf("The minimum logging level at which stack traces are captured, can be one of [%s, %s, %s, %s, %s]",
 				levelToString[DebugLevel],
 				levelToString[InfoLevel],
@@ -376,7 +387,9 @@ func (o *Options) AttachFlags(cmd *cobra.Command) {
 				levelToString[ErrorLevel],
 				levelToString[NoneLevel]))
 
-		cmd.PersistentFlags().StringVar(&o.logCallers, "log-caller", o.logCallers,
+		fs.StringVar(&o.logCallers, "log-caller", o.logCallers,
 			"Comma-separated list of scopes for which to include called information, scopes can be any of [default]")
 	}
+
+	return fs
 }


### PR DESCRIPTION
Cobra is great for CLI's but can be overkill for services, to allow keeping flags close to the domain it is nice to be able to use the provided flags in the `tetratelabs/log` package with the `spf13/pflag` package (which is the one used by `spf13/cobra` under the hood).

This PR adds the ability to add the log flags to either the provided or a newly created FlagSet.