### PR TITLE
Add an utility method to print all registered loggers

### DIFF
--- a/config.go
+++ b/config.go
@@ -55,6 +55,7 @@ package log
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -307,4 +308,25 @@ func Sync() error {
 	}
 
 	return err
+}
+
+// PrintRegisteredScopes logs all the registered scopes and their configured output level using` the default logger
+func PrintRegisteredScopes() {
+	s := Scopes()
+	pad := 0
+
+	names := make([]string, 0, len(s))
+	for n := range s {
+		names = append(names, n)
+		if len(n) > pad {
+			pad = len(n)
+		}
+	}
+	sort.Strings(names)
+
+	Info("registered logging scopes:")
+	for _, n := range names {
+		sc := s[n]
+		Infof("- %-*s %-5s %s", pad, sc.Name(), levelToString[sc.GetOutputLevel()], sc.Description())
+	}
 }


### PR DESCRIPTION
Add a utility method to print all registered scopes and their configured logging levels.

Only registered scopes can be configured in the command-line flags, otherwise, an error is raised. To make this less error-prone, this method can be used on program startup to provide an easy way to see all available loggers just by reading the first lines of a program output.

The output of this method is like:
```
2019-07-10T09:57:10.647324Z	info	registered logging scopes:
2019-07-10T09:57:10.647446Z	info	- audit           info  Messages from audit log system
2019-07-10T09:57:10.647459Z	info	- auth            info  Authentication messages server
2019-07-10T09:57:10.647465Z	info	- canonicalizer   info  gRPC interceptor responsible for canonicalizing names of incoming objects
2019-07-10T09:57:10.647471Z	info	- dag             info  Messages from the graph traversal system
2019-07-10T09:57:10.647476Z	info	- default         info  Unscoped logging messages.
2019-07-10T09:57:10.647478Z	info	- epp             info  Messages from the EPP
2019-07-10T09:57:10.647481Z	info	- migrations      info  Datanbase migration messages
2019-07-10T09:57:10.647484Z	info	- pap/location    info  Messages from the Location PAP
2019-07-10T09:57:10.647499Z	info	- pap/pkg         info  Messages from the PAP pkg
2019-07-10T09:57:10.647508Z	info	- pap/rbac        info  Messages from the RBAC PAP
2019-07-10T09:57:10.647513Z	info	- pap/time        info  Messages from the Time PAP
2019-07-10T09:57:10.647517Z	info	- pdp             info  Messages from the PDP engine
2019-07-10T09:57:10.647531Z	info	- pdp/audit       info  Messages from the PDP auditor
2019-07-10T09:57:10.647589Z	info	- pip/memory      info  Messages from the in-memory PIP implementation
2019-07-10T09:57:10.647603Z	info	- pip/sql         info  Messages from the SQL PIP implementation
2019-07-10T09:57:10.647610Z	info	- q               info  Messages from the Q system
2019-07-10T09:57:10.647616Z	info	- tcc/api         info  Messages from the TCC API Server
2019-07-10T09:57:10.647621Z	info	- tcc/bulk        debug Messages from the TCC bulk persistence layer
2019-07-10T09:57:10.647627Z	info	- tcc/migration   info  Messages from the TCC migrations
2019-07-10T09:57:10.647633Z	info	- tcc/persistence info  Messages from the TCC persistence layer
2019-07-10T09:57:10.647638Z	info	- tcc/q           info  Messages from the TCC Q system
2019-07-10T09:57:10.647644Z	info	- tcc/server      info  Messages from TCC
```