### PR TITLE
Allow unknown loggers to be defined

### DIFF
--- a/config.go
+++ b/config.go
@@ -55,6 +55,7 @@ package log
 
 import (
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 	"sync/atomic"
@@ -233,7 +234,7 @@ func updateScopes(options *Options, core zapcore.Core, errSink zapcore.WriteSync
 		if scope, ok := allScopes[s]; ok {
 			scope.SetLogCallers(true)
 		} else {
-			return fmt.Errorf("unknown scope '%s' specified", s)
+			_, _ = fmt.Fprintf(os.Stderr, "unknown scope '%s' specified", s)
 		}
 	}
 
@@ -259,7 +260,7 @@ func processLevels(allScopes map[string]*Scope, arg string, setter func(*Scope, 
 			}
 			return nil
 		} else {
-			return fmt.Errorf("unknown scope '%s' specified", s)
+			_, _ = fmt.Fprintf(os.Stderr, "unknown scope '%s' specified\n", s)
 		}
 	}
 

--- a/config_test.go
+++ b/config_test.go
@@ -112,11 +112,11 @@ func TestOddballs(t *testing.T) {
 		t.Error("Got success, expected failure")
 	}
 
-	o = DefaultOptions()
+	o = DefaultOptions() // Unknown scopes should be allowed
 	o.outputLevels = "foobar:debug"
 	err = Configure(o)
-	if err == nil {
-		t.Error("Got success, expected failure")
+	if err != nil {
+		t.Error(err)
 	}
 
 	o = DefaultOptions()
@@ -133,18 +133,18 @@ func TestOddballs(t *testing.T) {
 		t.Error("Got success, expected failure")
 	}
 
-	o = DefaultOptions()
+	o = DefaultOptions() // Unknown scopes should be allowed
 	o.stackTraceLevels = "foobar:debug"
 	err = Configure(o)
-	if err == nil {
-		t.Error("Got success, expected failure")
+	if err != nil {
+		t.Error(err)
 	}
 
-	o = DefaultOptions()
+	o = DefaultOptions() // Unknown scopes should be allowed
 	o.logCallers = "foobar"
 	err = Configure(o)
-	if err == nil {
-		t.Error("Got success, expected failure")
+	if err != nil {
+		t.Error(err)
 	}
 
 	o = DefaultOptions()


### PR DESCRIPTION
Provides better backwards-compat when removing scopes. There is no point in failing if an unknown scope is passed as long as you can configure the existing ones.