### PR TITLE
Add methods to work with the level names

### DIFF
--- a/options.go
+++ b/options.go
@@ -41,6 +41,16 @@ const (
 // Level is an enumeration of all supported log levels.
 type Level int
 
+// String returns the name of the level
+func (l Level) String() string {
+	return levelToString[l]
+}
+
+// LevelFrom returns the level for the given name
+func LevelFrom(name string) Level {
+	return stringToLevel[name]
+}
+
 const (
 	// NoneLevel disables logging
 	NoneLevel Level = iota


### PR DESCRIPTION
There were no public methods to convert levels to strings and vice-versa. This PR adds a couple convenience methods to expose that.

@chirauki With this we can remove the copy of the log level maps we had in the admin server and your tctl PR.