### PR TITLE
Return the discard log by default

### DIFF
--- a/discard.go
+++ b/discard.go
@@ -20,66 +20,19 @@ import (
 	"github.com/tetratelabs/telemetry"
 )
 
-// compile time check for compatibility with the telemetry.Logger interface.
-var _ telemetry.Logger = (*Discard)(nil)
+// Discard is a noop logger. It does not emit log message and does not record metric values.
+// Adding values to the logger binding it to a Context will do nothing.
+var Discard ScopedLogger = &discard{}
 
-// Discard is a logger that does not emit log messages but still emits metrics.
-type Discard struct {
-	// ctx holds the Context to extract key-value pairs from to be added to each
-	// log line.
-	ctx context.Context
-	// metric holds the Metric to increment each time Info() or Error() is called.
-	metric telemetry.Metric
-}
-
-// NewDiscard creates a new Discard logger
-func NewDiscard() *Discard {
-	return &Discard{ctx: context.Background()}
-}
-
-// discardName is the name for the discard logging scope
+// discardName is the name of the discarding logger.
 const discardName = "/dev/null"
 
-// Name implements the Scope interface
-func (*Discard) Name() string {
-	return discardName
-}
+type discard struct{}
 
-// Info emits the configured metric, if any.
-func (d *Discard) Info(string, ...interface{}) {
-	// even if we don't output the log line due to the level configuration,
-	// we always emit the Metric if it is set.
-	if d.metric != nil {
-		d.metric.RecordContext(d.ctx, 1)
-	}
-}
-
-// Error emits the configured metric, if any.
-func (d *Discard) Error(string, error, ...interface{}) {
-	// even if we don't output the log line due to the level configuration,
-	// we always emit the Metric if it is set.
-	if d.metric != nil {
-		d.metric.RecordContext(d.ctx, 1)
-	}
-}
-
-// Debug is a noop
-func (d *Discard) Debug(string, ...interface{}) {}
-
-// With is a noop
-func (d *Discard) With(...interface{}) telemetry.Logger {
-	return d
-}
-
-// Context attaches provided Context to the Logger allowing metadata found in
-// this context to be used for metrics labels.
-func (d *Discard) Context(ctx context.Context) telemetry.Logger {
-	return &Discard{ctx: ctx, metric: d.metric}
-}
-
-// Metric attaches provided Metric to the Logger allowing this metric to
-// record each invocation of Info and Error log lines. If context is available
-// in the logger, it can be used for Metrics labels.
-func (d *Discard) Metric(m telemetry.Metric) telemetry.Logger {
-	return &Discard{ctx: d.ctx, metric: m}
-}
+func (discard) Name() string                                { return discardName }
+func (discard) Info(string, ...interface{})                 {}
+func (discard) Error(string, error, ...interface{})         {}
+func (discard) Debug(string, ...interface{})                {}
+func (d *discard) With(...interface{}) telemetry.Logger     { return d }
+func (d *discard) Context(context.Context) telemetry.Logger { return d }
+func (d *discard) Metric(telemetry.Metric) telemetry.Logger { return d }

--- a/discard.go
+++ b/discard.go
@@ -21,10 +21,10 @@ import (
 )
 
 // compile time check for compatibility with the telemetry.Logger interface.
-var _ telemetry.Logger = (*discard)(nil)
+var _ telemetry.Logger = (*Discard)(nil)
 
-// discard is a logger that does not emit log messages but still emits metrics.
-type discard struct {
+// Discard is a logger that does not emit log messages but still emits metrics.
+type Discard struct {
 	// ctx holds the Context to extract key-value pairs from to be added to each
 	// log line.
 	ctx context.Context
@@ -32,13 +32,21 @@ type discard struct {
 	metric telemetry.Metric
 }
 
-// Discard returns a nre logger that discards log messages but still emits the corresponding metrics, if set.
-func Discard() telemetry.Logger {
-	return &discard{ctx: context.Background()}
+// NewDiscard creates a new Discard logger
+func NewDiscard() *Discard {
+	return &Discard{ctx: context.Background()}
+}
+
+// discardName is the name for the discard logging scope
+const discardName = "/dev/null"
+
+// Name implements the Scope interface
+func (*Discard) Name() string {
+	return discardName
 }
 
 // Info emits the configured metric, if any.
-func (d *discard) Info(string, ...interface{}) {
+func (d *Discard) Info(string, ...interface{}) {
 	// even if we don't output the log line due to the level configuration,
 	// we always emit the Metric if it is set.
 	if d.metric != nil {
@@ -47,7 +55,7 @@ func (d *discard) Info(string, ...interface{}) {
 }
 
 // Error emits the configured metric, if any.
-func (d *discard) Error(string, error, ...interface{}) {
+func (d *Discard) Error(string, error, ...interface{}) {
 	// even if we don't output the log line due to the level configuration,
 	// we always emit the Metric if it is set.
 	if d.metric != nil {
@@ -56,22 +64,22 @@ func (d *discard) Error(string, error, ...interface{}) {
 }
 
 // Debug is a noop
-func (d *discard) Debug(string, ...interface{}) {}
+func (d *Discard) Debug(string, ...interface{}) {}
 
 // With is a noop
-func (d *discard) With(...interface{}) telemetry.Logger {
+func (d *Discard) With(...interface{}) telemetry.Logger {
 	return d
 }
 
 // Context attaches provided Context to the Logger allowing metadata found in
 // this context to be used for metrics labels.
-func (d *discard) Context(ctx context.Context) telemetry.Logger {
-	return &discard{ctx: ctx, metric: d.metric}
+func (d *Discard) Context(ctx context.Context) telemetry.Logger {
+	return &Discard{ctx: ctx, metric: d.metric}
 }
 
 // Metric attaches provided Metric to the Logger allowing this metric to
 // record each invocation of Info and Error log lines. If context is available
 // in the logger, it can be used for Metrics labels.
-func (d *discard) Metric(m telemetry.Metric) telemetry.Logger {
-	return &discard{ctx: d.ctx, metric: m}
+func (d *Discard) Metric(m telemetry.Metric) telemetry.Logger {
+	return &Discard{ctx: d.ctx, metric: m}
 }

--- a/discard_test.go
+++ b/discard_test.go
@@ -35,16 +35,15 @@ func TestDiscard(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			logger := NewDiscard()
 
 			metric := mockMetric{}
 			ctx := telemetry.KeyValuesToContext(context.Background(), "ctx", "value")
-			l := logger.Context(ctx).Metric(&metric).With().With("lvl", LevelInfo).With("missing")
+			l := Discard.Context(ctx).Metric(&metric).With().With("lvl", LevelInfo).With("missing")
 
 			tt.logfunc(l)
 
-			if metric.count != tt.metricCount {
-				t.Fatalf("metric.count=%v, want %v", metric.count, tt.metricCount)
+			if metric.count != 0 {
+				t.Fatalf("metric.count=%v, want 0", metric.count)
 			}
 		})
 	}

--- a/discard_test.go
+++ b/discard_test.go
@@ -35,7 +35,7 @@ func TestDiscard(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			logger := Discard()
+			logger := NewDiscard()
 
 			metric := mockMetric{}
 			ctx := telemetry.KeyValuesToContext(context.Background(), "ctx", "value")

--- a/example_test.go
+++ b/example_test.go
@@ -28,7 +28,7 @@ func mockTime() time.Time {
 
 func ExampleLogger() {
 	logger := Register("mylogger", "Custom logger")
-	logger.now = mockTime // Mock time to have a consistent output
+	logger.(*Logger).now = mockTime // Mock time to have a consistent output
 
 	// Normal and error logging
 	logger.Info("an info message with values", "key", "value")
@@ -36,7 +36,7 @@ func ExampleLogger() {
 
 	// Changing log levels at runtime
 	logger.Debug("a debug message")
-	logger.SetLevel(LevelDebug)
+	logger.(*Logger).SetLevel(LevelDebug)
 	logger.Debug("an enabled debug message")
 
 	// Propagating values
@@ -52,7 +52,7 @@ func ExampleLogger() {
 
 func ExampleLogger_unstructured() {
 	unstructured := RegisterUnstructured("unstructured-example", "Unstructured logger")
-	unstructured.now = mockTime // Mock time to have a consistent output
+	unstructured.(*Logger).now = mockTime // Mock time to have a consistent output
 
 	// Normal and error logging
 	unstructured.Info("an info message with %s", "a value")
@@ -60,7 +60,7 @@ func ExampleLogger_unstructured() {
 
 	// Changing log levels at runtime
 	unstructured.Debug("a debug message")
-	unstructured.SetLevel(LevelDebug)
+	unstructured.(*Logger).SetLevel(LevelDebug)
 	unstructured.Debug("an enabled debug message")
 
 	// Propagating values

--- a/logger_test.go
+++ b/logger_test.go
@@ -55,7 +55,7 @@ func TestLogger(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			logger := Register(tt.name, "test logger")
+			logger := Register(tt.name, "test logger").(*Logger)
 			logger.SetLevel(tt.level)
 			if logger.Name() != tt.name {
 				t.Fatalf("loger.Name()=%s, want: %s", logger.Name(), tt.name)
@@ -116,7 +116,7 @@ func TestAsLevel(t *testing.T) {
 }
 
 func TestSetLevel(t *testing.T) {
-	logger := Register("level", "test logger")
+	logger := Register("level", "test logger").(*Logger)
 	withvalues := logger.With("key", "value").(*Logger)
 	logger.SetLevel(LevelDebug)
 

--- a/registry.go
+++ b/registry.go
@@ -20,15 +20,15 @@ import (
 	"github.com/tetratelabs/telemetry"
 )
 
-// Scope is a named logger that can be configured independently
-type Scope interface {
+// ScopedLogger is a named logger that can be configured independently
+type ScopedLogger interface {
 	telemetry.Logger
 	Name() string
 }
 
 // Register a new logger with the given name.
 // If the logger already exists, the already registered logger is returned.
-func Register(name, description string) Scope {
+func Register(name, description string) ScopedLogger {
 	if l, ok := reg.GetLogger(name); ok {
 		return l
 	}
@@ -41,7 +41,7 @@ func Register(name, description string) Scope {
 
 // RegisterUnstructured a new unstructured logger with the given name.
 // If the logger already exists, the already registered logger is returned.
-func RegisterUnstructured(name, description string) Scope {
+func RegisterUnstructured(name, description string) ScopedLogger {
 	if l, ok := reg.GetLogger(name); ok {
 		return l
 	}
@@ -53,29 +53,29 @@ func RegisterUnstructured(name, description string) Scope {
 }
 
 // Loggers returns the list of all registered loggers.
-func Loggers() []Scope { return reg.Loggers() }
+func Loggers() []ScopedLogger { return reg.Loggers() }
 
 // GetLogger gets a registered logger by name.
-func GetLogger(name string) Scope {
+func GetLogger(name string) ScopedLogger {
 	logger, _ := reg.GetLogger(name)
 	return logger
 }
 
 // reg is a registry of all registered loggers.
-var reg = &registry{loggers: make(map[string]Scope)}
+var reg = &registry{loggers: make(map[string]ScopedLogger)}
 
 // registry keeps track of all registered loggers.
 type registry struct {
 	mu      sync.RWMutex
-	loggers map[string]Scope
+	loggers map[string]ScopedLogger
 }
 
 // Loggers returns the list of all registered loggers.
-func (r *registry) Loggers() []Scope {
+func (r *registry) Loggers() []ScopedLogger {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	loggers := make([]Scope, 0, len(r.loggers))
+	loggers := make([]ScopedLogger, 0, len(r.loggers))
 	for _, l := range r.loggers {
 		loggers = append(loggers, l)
 	}
@@ -84,20 +84,20 @@ func (r *registry) Loggers() []Scope {
 }
 
 // GetLogger a registered logger by name.
-func (r *registry) GetLogger(name string) (Scope, bool) {
+func (r *registry) GetLogger(name string) (ScopedLogger, bool) {
 	r.mu.RLock()
 	logger, ok := r.loggers[name]
 	r.mu.RUnlock()
 
 	if !ok {
-		return NewDiscard(), false
+		return Discard, false
 	}
 
 	return logger, true
 }
 
 // Register a logger into the registry.
-func (r *registry) Register(logger Scope) {
+func (r *registry) Register(logger ScopedLogger) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 

--- a/registry.go
+++ b/registry.go
@@ -16,17 +16,24 @@ package log
 
 import (
 	"sync"
+
+	"github.com/tetratelabs/telemetry"
 )
+
+// Scope is a named logger that can be configured independently
+type Scope interface {
+	telemetry.Logger
+	Name() string
+}
 
 // Register a new logger with the given name.
 // If the logger already exists, the already registered logger is returned.
-func Register(name, description string) *Logger {
-	l := reg.GetLogger(name)
-	if l != nil {
+func Register(name, description string) Scope {
+	if l, ok := reg.GetLogger(name); ok {
 		return l
 	}
 
-	l = newLogger(name, description)
+	l := newLogger(name, description)
 	reg.Register(l)
 
 	return l
@@ -34,39 +41,41 @@ func Register(name, description string) *Logger {
 
 // RegisterUnstructured a new unstructured logger with the given name.
 // If the logger already exists, the already registered logger is returned.
-func RegisterUnstructured(name, description string) *Logger {
-	l := reg.GetLogger(name)
-	if l != nil {
+func RegisterUnstructured(name, description string) Scope {
+	if l, ok := reg.GetLogger(name); ok {
 		return l
 	}
 
-	l = newUnstructured(name, description)
+	l := newUnstructured(name, description)
 	reg.Register(l)
 
 	return l
 }
 
 // Loggers returns the list of all registered loggers.
-func Loggers() []*Logger { return reg.Loggers() }
+func Loggers() []Scope { return reg.Loggers() }
 
 // GetLogger gets a registered logger by name.
-func GetLogger(name string) *Logger { return reg.GetLogger(name) }
+func GetLogger(name string) Scope {
+	logger, _ := reg.GetLogger(name)
+	return logger
+}
 
 // reg is a registry of all registered loggers.
-var reg = &registry{loggers: make(map[string]*Logger)}
+var reg = &registry{loggers: make(map[string]Scope)}
 
 // registry keeps track of all registered loggers.
 type registry struct {
 	mu      sync.RWMutex
-	loggers map[string]*Logger
+	loggers map[string]Scope
 }
 
 // Loggers returns the list of all registered loggers.
-func (r *registry) Loggers() []*Logger {
+func (r *registry) Loggers() []Scope {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	loggers := make([]*Logger, 0, len(r.loggers))
+	loggers := make([]Scope, 0, len(r.loggers))
 	for _, l := range r.loggers {
 		loggers = append(loggers, l)
 	}
@@ -75,15 +84,20 @@ func (r *registry) Loggers() []*Logger {
 }
 
 // GetLogger a registered logger by name.
-func (r *registry) GetLogger(name string) *Logger {
+func (r *registry) GetLogger(name string) (Scope, bool) {
 	r.mu.RLock()
-	defer r.mu.RUnlock()
+	logger, ok := r.loggers[name]
+	r.mu.RUnlock()
 
-	return r.loggers[name]
+	if !ok {
+		return NewDiscard(), false
+	}
+
+	return logger, true
 }
 
 // Register a logger into the registry.
-func (r *registry) Register(logger *Logger) {
+func (r *registry) Register(logger Scope) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 

--- a/registry_test.go
+++ b/registry_test.go
@@ -21,13 +21,14 @@ func TestLoggers(t *testing.T) {
 	unstructured := RegisterUnstructured("unstructured", "test logger")
 
 	// Verify loggers are registered
-	if GetLogger("custom-logger") == nil {
+	if GetLogger("custom-logger").Name() == discardName {
 		t.Fatal("custom-logger was not registered")
 	}
-	if GetLogger("unstructured") == nil {
+	if GetLogger("unstructured").Name() == discardName {
 		t.Fatal("unstructured was not registered")
 	}
-	if GetLogger("unexisting") != nil {
+
+	if GetLogger("unexisting").Name() != discardName {
 		t.Fatal("unexisting logger was not expected to be registered")
 	}
 

--- a/unstructured_test.go
+++ b/unstructured_test.go
@@ -50,7 +50,7 @@ func TestUnstructured(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			logger := RegisterUnstructured(tt.name, "test logger")
+			logger := RegisterUnstructured(tt.name, "test logger").(*Logger)
 			logger.SetLevel(tt.level)
 			if logger.Name() != tt.name {
 				t.Fatalf("loger.Name()=%s, want: %s", logger.Name(), tt.name)


### PR DESCRIPTION
~~Opening as draft to see if this would be a good default, as it is very opinionated.~~

In the scope manager, return the `Discard` log by default when calling `log.GetLogger("name")` if no logger with that name has been defined yet. This enables the use case where loggers are retrieved from the scope manager from a constructor (see https://github.com/tetrateio/ngac/pull/377#issuecomment-991239416) by providing a reasonable default when the scopes have not been explicitly defined (that's usually done in the main function), for example in unit tests.