### PR TITLE
Reduce allocations and memory usage in the loggers

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -18,3 +18,5 @@ coverage:
         target: auto
         # allow a potential drop of up to 5%
         threshold: 5%
+        branches:
+          - v2

--- a/Makefile
+++ b/Makefile
@@ -28,9 +28,10 @@ TEST_OPTS ?= -race
 test:
 	go test $(TEST_OPTS) ./...
 
+BENCH_OPTS ?=
 .PHONY: bench
 bench:
-	go test -bench=. ./...
+	go test -bench=. $(BENCH_OPTS) ./...
 
 .PHONY: coverage
 coverage:

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,10 @@ TEST_OPTS ?= -race
 test:
 	go test $(TEST_OPTS) ./...
 
+.PHONY: bench
+bench:
+	go test -bench=. ./...
+
 .PHONY: coverage
 coverage:
 	mkdir -p build

--- a/example_test.go
+++ b/example_test.go
@@ -71,5 +71,5 @@ func ExampleLogger_unstructured() {
 	// 2021/12/09 17:37:46  info 	unstructured-example	an info message with a value
 	// 2021/12/09 17:37:46  error	unstructured-example	validation error in arg1: validation failed
 	// 2021/12/09 17:37:46  debug	unstructured-example	an enabled debug message
-	// 2021/12/09 17:37:46  info 	unstructured-example	enriched message [ request-id=123 component="middleware" ]
+	// 2021/12/09 17:37:46  info 	unstructured-example	enriched message [request-id=123 component="middleware"]
 }

--- a/logger.go
+++ b/logger.go
@@ -185,34 +185,52 @@ func (l *Logger) clone() *Logger {
 func structuredLog(l *Logger, level Level, msg string, err error, keyValues ...interface{}) {
 	t := l.now()
 
-	// merge all args
-	args := append([]interface{}{}, telemetry.KeyValuesFromContext(l.ctx)...)
-	args = append(args, l.args...)
-	args = append(args, keyValues...)
-	if len(keyValues)%2 != 0 {
-		args = append(args, "(MISSING)")
-	}
-	if err != nil {
-		args = append(args, "error", err.Error())
-	}
-
 	var out bytes.Buffer
-	_, _ = out.WriteString(fmt.Sprintf(`time="%d/%02d/%02d %02d:%02d:%02d"`,
-		t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second()))
-	_, _ = out.WriteString(fmt.Sprintf(" level=%v", level))
-	_, _ = out.WriteString(fmt.Sprintf(" scope=%q", l.name))
-	_, _ = out.WriteString(fmt.Sprintf(" msg=%q", msg))
 
-	for i := 0; i < len(args); i += 2 {
-		if k, ok := args[i].(string); ok {
-			if v, ok := args[i+1].(string); ok {
-				_, _ = out.WriteString(fmt.Sprintf(` %s=%q`, k, v))
-			} else {
-				_, _ = out.WriteString(fmt.Sprintf(` %s=%v`, k, args[i+1]))
-			}
-		}
+	_, _ = out.WriteString(
+		fmt.Sprintf(`time="%d/%02d/%02d %02d:%02d:%02d" level=%v scope=%q msg=%q`,
+			t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second(),
+			level, l.name, msg))
+
+	writeArgs(&out, telemetry.KeyValuesFromContext(l.ctx))
+	writeArgs(&out, l.args)
+	writeArgs(&out, keyValues)
+
+	if err != nil {
+		_, _ = out.WriteString(" error=\"")
+		_, _ = out.WriteString(err.Error())
+		_, _ = out.WriteString("\"")
 	}
 
 	_, _ = out.WriteString("\n")
 	_, _ = out.WriteTo(l.writer)
+}
+
+// writeArgs writes the list of arguments to the buffer
+func writeArgs(b *bytes.Buffer, args []interface{}) {
+	n := len(args)
+	for i := 0; i < n; i += 2 {
+		if _, ok := args[i].(string); !ok {
+			continue
+		}
+		_, _ = b.WriteString(" ")
+		writeKeyValue(b, args, i, n)
+	}
+}
+
+// writeKeyValue writes a key value pair to the buffer
+func writeKeyValue(b *bytes.Buffer, args []interface{}, i, n int) {
+	k := args[i].(string) // precondition: this has already been checked, and it is safe to cast
+	_, _ = b.WriteString(k)
+	_, _ = b.WriteString("=")
+	if i+1 >= n {
+		_, _ = b.WriteString("\"(MISSING)\"")
+		return
+	}
+
+	if v, ok := args[i+1].(string); ok {
+		_, _ = b.WriteString(fmt.Sprintf("%q", v))
+	} else {
+		_, _ = b.WriteString(fmt.Sprintf("%v", args[i+1]))
+	}
 }

--- a/logger.go
+++ b/logger.go
@@ -188,8 +188,8 @@ func structuredLog(l *Logger, level Level, msg string, err error, keyValues ...i
 	var out bytes.Buffer
 
 	_, _ = out.WriteString(
-		fmt.Sprintf(`time="%d/%02d/%02d %02d:%02d:%02d" level=%v scope=%q msg=%q`,
-			t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second(),
+		fmt.Sprintf(`time="%d/%02d/%02d %02d:%02d:%02d" level=%s scope=%q msg=%q`,
+			t.Year(), int(t.Month()), t.Day(), t.Hour(), t.Minute(), t.Second(),
 			level, l.name, msg))
 
 	writeArgs(&out, telemetry.KeyValuesFromContext(l.ctx))

--- a/logger_test.go
+++ b/logger_test.go
@@ -39,15 +39,16 @@ func TestLogger(t *testing.T) {
 		{"disabled-error", LevelNone, func(l telemetry.Logger) { l.Error("text", errors.New("error")) }, regexp.MustCompile("^$"), 1},
 		{"info", LevelInfo, func(l telemetry.Logger) { l.Info("text") }, match("info", LevelInfo, ""), 1},
 		{"info-missing", LevelInfo, func(l telemetry.Logger) { l.Info("text", "where") }, match("info-missing", LevelInfo, ` where="\(MISSING\)"`), 1},
-		{"info-with-values", LevelInfo, func(l telemetry.Logger) { l.Info("text", "where", "there") }, match("info-with-values", LevelInfo, ` where="there"`), 1},
+		{"info-with-values", LevelInfo, func(l telemetry.Logger) { l.Info("text", "where", "there", 1, "1") },
+			match("info-with-values", LevelInfo, ` where="there"`), 1},
 		{"error", LevelInfo, func(l telemetry.Logger) { l.Error("text", errors.New("error")) }, match("error", LevelError, ` error="error"`), 1},
 		{"error-missing", LevelInfo, func(l telemetry.Logger) { l.Error("text", errors.New("error"), "where") },
 			match("error-missing", LevelError, ` where="\(MISSING\)" error="error"`), 1},
-		{"error-with-values", LevelInfo, func(l telemetry.Logger) { l.Error("text", errors.New("error"), "where", "there") },
+		{"error-with-values", LevelInfo, func(l telemetry.Logger) { l.Error("text", errors.New("error"), "where", "there", 1, "1") },
 			match("error-with-values", LevelError, ` where="there" error="error"`), 1},
 		{"debug", LevelDebug, func(l telemetry.Logger) { l.Debug("text") }, match("debug", LevelDebug, ""), 0},
 		{"debug-missing", LevelDebug, func(l telemetry.Logger) { l.Debug("text", "where") }, match("debug-missing", LevelDebug, ` where="\(MISSING\)"`), 0},
-		{"debug-with-values", LevelDebug, func(l telemetry.Logger) { l.Debug("text", "where", "there") },
+		{"debug-with-values", LevelDebug, func(l telemetry.Logger) { l.Debug("text", "where", "there", 1, "1") },
 			match("debug-with-values", LevelDebug, ` where="there"`), 0},
 	}
 
@@ -71,7 +72,7 @@ func TestLogger(t *testing.T) {
 
 			metric := mockMetric{}
 			ctx := telemetry.KeyValuesToContext(context.Background(), "ctx", "value")
-			l := logger.Context(ctx).Metric(&metric).With().With("lvl", LevelInfo).With("missing")
+			l := logger.Context(ctx).Metric(&metric).With().With(1, "").With("lvl", LevelInfo).With("missing")
 
 			tt.logfunc(l)
 

--- a/logger_test.go
+++ b/logger_test.go
@@ -125,6 +125,7 @@ func TestSetLevel(t *testing.T) {
 	}
 }
 
+func BenchmarkStructuredLog0Args(b *testing.B)  { benchmarkLogger(b, 0, newLogger, structuredLog) }
 func BenchmarkStructuredLog3Args(b *testing.B)  { benchmarkLogger(b, 1, newLogger, structuredLog) }
 func BenchmarkStructuredLog9Args(b *testing.B)  { benchmarkLogger(b, 3, newLogger, structuredLog) }
 func BenchmarkStructuredLog15Args(b *testing.B) { benchmarkLogger(b, 5, newLogger, structuredLog) }

--- a/unstructured.go
+++ b/unstructured.go
@@ -38,43 +38,40 @@ func newUnstructured(name, description string) *Logger {
 func unstructuredLog(l *Logger, level Level, msg string, err error, keyValues ...interface{}) {
 	t := l.now()
 
-	// merge contextual args
-	contextualArgs := append([]interface{}{}, telemetry.KeyValuesFromContext(l.ctx)...)
-	contextualArgs = append(contextualArgs, l.args...)
-
-	// args for the unstructured message format string
-	args := append([]interface{}{}, keyValues...)
-	if err != nil {
-		args = append(args, err)
-	}
-
 	var out bytes.Buffer
 	_, _ = out.WriteString(fmt.Sprintf(unstructuredFormatString,
 		t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second(),
 		level, l.name))
 
-	_, _ = out.WriteString(fmt.Sprintf(msg, args...))
+	if err != nil {
+		keyValues = append(keyValues, err)
+	}
+	_, _ = out.WriteString(fmt.Sprintf(msg, keyValues...))
 
-	if len(contextualArgs) > 0 {
+	fromCtx := telemetry.KeyValuesFromContext(l.ctx)
+	nCtx := len(fromCtx)
+	nArgs := len(l.args)
+
+	if nCtx > 0 { // write the context args without a Leading whitespace
 		_, _ = out.WriteString(" [")
-		writeKeyValue(&out, contextualArgs[0], contextualArgs[1])
-		for i := 2; i < len(contextualArgs); i += 2 {
-			_, _ = out.WriteString(" ")
-			writeKeyValue(&out, contextualArgs[i], contextualArgs[i+1])
+		writeKeyValue(&out, fromCtx, 0, nCtx)
+		writeArgs(&out, fromCtx[2:])
+	}
+
+	if nArgs > 0 {
+		if nCtx > 0 {
+			writeArgs(&out, l.args)
+		} else { // write the logger args without a Leading whitespace
+			_, _ = out.WriteString(" [")
+			writeKeyValue(&out, l.args, 0, nArgs)
+			writeArgs(&out, l.args[2:])
 		}
+	}
+
+	if nCtx > 0 || nArgs > 0 {
 		_, _ = out.WriteString("]")
 	}
 
 	_, _ = out.WriteString("\n")
 	_, _ = out.WriteTo(l.writer)
-}
-
-func writeKeyValue(b *bytes.Buffer, key interface{}, value interface{}) {
-	if k, ok := key.(string); ok {
-		if v, ok := value.(string); ok {
-			_, _ = b.WriteString(fmt.Sprintf(`%s=%q`, k, v))
-		} else {
-			_, _ = b.WriteString(fmt.Sprintf(`%s=%v`, k, value))
-		}
-	}
 }

--- a/unstructured.go
+++ b/unstructured.go
@@ -57,18 +57,24 @@ func unstructuredLog(l *Logger, level Level, msg string, err error, keyValues ..
 
 	if len(contextualArgs) > 0 {
 		_, _ = out.WriteString(" [")
-		for i := 0; i < len(contextualArgs); i += 2 {
-			if k, ok := contextualArgs[i].(string); ok {
-				if v, ok := contextualArgs[i+1].(string); ok {
-					_, _ = out.WriteString(fmt.Sprintf(` %s=%q`, k, v))
-				} else {
-					_, _ = out.WriteString(fmt.Sprintf(` %s=%v`, k, contextualArgs[i+1]))
-				}
-			}
+		writeKeyValue(&out, contextualArgs[0], contextualArgs[1])
+		for i := 2; i < len(contextualArgs); i += 2 {
+			_, _ = out.WriteString(" ")
+			writeKeyValue(&out, contextualArgs[i], contextualArgs[i+1])
 		}
-		_, _ = out.WriteString(" ]")
+		_, _ = out.WriteString("]")
 	}
 
 	_, _ = out.WriteString("\n")
 	_, _ = out.WriteTo(l.writer)
+}
+
+func writeKeyValue(b *bytes.Buffer, key interface{}, value interface{}) {
+	if k, ok := key.(string); ok {
+		if v, ok := value.(string); ok {
+			_, _ = b.WriteString(fmt.Sprintf(`%s=%q`, k, v))
+		} else {
+			_, _ = b.WriteString(fmt.Sprintf(`%s=%v`, k, value))
+		}
+	}
 }

--- a/unstructured.go
+++ b/unstructured.go
@@ -40,7 +40,7 @@ func unstructuredLog(l *Logger, level Level, msg string, err error, keyValues ..
 
 	var out bytes.Buffer
 	_, _ = out.WriteString(fmt.Sprintf(unstructuredFormatString,
-		t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second(),
+		t.Year(), int(t.Month()), t.Day(), t.Hour(), t.Minute(), t.Second(),
 		level, l.name))
 
 	if err != nil {

--- a/unstructured_test.go
+++ b/unstructured_test.go
@@ -64,7 +64,7 @@ func TestUnstructured(t *testing.T) {
 
 			metric := mockMetric{}
 			ctx := telemetry.KeyValuesToContext(context.Background(), "ctx", "value")
-			l := logger.Context(ctx).Metric(&metric).With().With("lvl", LevelInfo).With("missing")
+			l := logger.Context(ctx).Metric(&metric).With().With(1, "").With("lvl", LevelInfo).With("missing")
 
 			tt.logfunc(l)
 
@@ -80,5 +80,5 @@ func TestUnstructured(t *testing.T) {
 }
 
 func matchUnstructured(n string, l Level, msg string) *regexp.Regexp {
-	return regexp.MustCompile(fmt.Sprintf("^%s  %-5v\t%-10s\\t%s \\[ ctx=\"value\" lvl=info missing=\"\\(MISSING\\)\" \\]\\n$", rprefix, l, n, msg))
+	return regexp.MustCompile(fmt.Sprintf("^%s  %-5v\t%-10s\\t%s \\[ctx=\"value\" lvl=info missing=\"\\(MISSING\\)\"\\]\\n$", rprefix, l, n, msg))
 }

--- a/unstructured_test.go
+++ b/unstructured_test.go
@@ -79,6 +79,10 @@ func TestUnstructured(t *testing.T) {
 	}
 }
 
+func BenchmarkUnstructuredLog0Args(b *testing.B) {
+	benchmarkLogger(b, 0, newUnstructured, unstructuredLog)
+}
+
 func BenchmarkUnstructuredLog3Args(b *testing.B) {
 	benchmarkLogger(b, 1, newUnstructured, unstructuredLog)
 }

--- a/unstructured_test.go
+++ b/unstructured_test.go
@@ -79,6 +79,22 @@ func TestUnstructured(t *testing.T) {
 	}
 }
 
+func BenchmarkUnstructuredLog3Args(b *testing.B) {
+	benchmarkLogger(b, 1, newUnstructured, unstructuredLog)
+}
+
+func BenchmarkUnstructuredLog9Args(b *testing.B) {
+	benchmarkLogger(b, 3, newUnstructured, unstructuredLog)
+}
+
+func BenchmarkUnstructuredLog15Args(b *testing.B) {
+	benchmarkLogger(b, 5, newUnstructured, unstructuredLog)
+}
+
+func BenchmarkUnstructuredLog30Args(b *testing.B) {
+	benchmarkLogger(b, 10, newUnstructured, unstructuredLog)
+}
+
 func matchUnstructured(n string, l Level, msg string) *regexp.Regexp {
 	return regexp.MustCompile(fmt.Sprintf("^%s  %-5v\t%-10s\\t%s \\[ctx=\"value\" lvl=info missing=\"\\(MISSING\\)\"\\]\\n$", rprefix, l, n, msg))
 }


### PR DESCRIPTION
This PR refactors the loggers to reduce the number of allocations and amount of memory needed for each log line. Benchmarks are done by assuming 0, 3, 9, 15, and 30 total arguments.

Before:
```
nacx ~/src/log (v2) $ go test -bench=.

BenchmarkStructuredLog0Args-8      	 1215139	       925.9 ns/op	     328 B/op	       9 allocs/op
BenchmarkStructuredLog3Args-8      	  825308	      1379 ns/op	     624 B/op	      18 allocs/op
BenchmarkStructuredLog9Args-8      	  562828	      2076 ns/op	    1216 B/op	      30 allocs/op
BenchmarkStructuredLog15Args-8     	  412002	      2846 ns/op	    2096 B/op	      43 allocs/op
BenchmarkStructuredLog30Args-8     	  259807	      4813 ns/op	    3577 B/op	      73 allocs/op

BenchmarkUnstructuredLog0Args-8    	 1735750	       688.6 ns/op	     144 B/op	       5 allocs/op
BenchmarkUnstructuredLog3Args-8    	  989944	      1152 ns/op	     536 B/op	      13 allocs/op
BenchmarkUnstructuredLog9Args-8    	  651796	      1794 ns/op	     952 B/op	      21 allocs/op
BenchmarkUnstructuredLog15Args-8   	  491506	      2402 ns/op	    1400 B/op	      29 allocs/op
BenchmarkUnstructuredLog30Args-8   	  295832	      4042 ns/op	    3177 B/op	      50 allocs/op
```

After:
```
nacx ~/src/log (format) $ go test -bench=.

BenchmarkStructuredLog0Args-8      	 1453257	       776.0 ns/op	     312 B/op	       6 allocs/op
BenchmarkStructuredLog3Args-8      	 1227420	       987.8 ns/op	     312 B/op	       6 allocs/op
BenchmarkStructuredLog9Args-8      	  792440	      1515 ns/op	     600 B/op	       7 allocs/op
BenchmarkStructuredLog15Args-8     	  611298	      2145 ns/op	     600 B/op	       7 allocs/op
BenchmarkStructuredLog30Args-8     	  413978	      2881 ns/op	    1208 B/op	       8 allocs/op

BenchmarkUnstructuredLog0Args-8    	 1811126	       647.8 ns/op	     144 B/op	       5 allocs/op
BenchmarkUnstructuredLog3Args-8    	 1282764	       988.5 ns/op	     360 B/op	       6 allocs/op
BenchmarkUnstructuredLog9Args-8    	  843518	      1411 ns/op	     424 B/op	       6 allocs/op
BenchmarkUnstructuredLog15Args-8   	  668487	      1747 ns/op	     520 B/op	       6 allocs/op
BenchmarkUnstructuredLog30Args-8   	  425914	      2847 ns/op	    1416 B/op	       7 allocs/op
```