### PR TITLE
Add a method to allow changing the writer for a logger

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -162,6 +162,14 @@ func (l *Logger) Metric(m telemetry.Metric) telemetry.Logger {
 	return newLogger
 }
 
+// Writer configures the writer where all log messages will be emitted.
+// This is mostly used in unit tests to allow sending logs to a buffer.
+func (l *Logger) Writer(w io.Writer) *Logger {
+	newLogger := l.clone()
+	newLogger.writer = w
+	return newLogger
+}
+
 // clone the current logger and return it
 func (l *Logger) clone() *Logger {
 	newLogger := &Logger{

--- a/logger_test.go
+++ b/logger_test.go
@@ -69,7 +69,7 @@ func TestLogger(t *testing.T) {
 
 			// Overwrite the output of the loggers to check the output messages
 			var out bytes.Buffer
-			logger.writer = &out
+			logger = logger.Writer(&out)
 
 			metric := mockMetric{}
 			ctx := telemetry.KeyValuesToContext(context.Background(), "ctx", "value")
@@ -149,8 +149,7 @@ func benchmarkLogger(
 		args = append(args, fmt.Sprintf("arg%d", i), i)
 	}
 
-	logger = logger.Context(ctx).(*Logger)
-	logger.writer = io.Discard
+	logger = logger.Context(ctx).(*Logger).Writer(io.Discard)
 
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {


### PR DESCRIPTION
This will make it much easier to mock the writer for the loggers and unit test objects that use this logging framework.