### PR TITLE
Adds Flattened logger

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -50,7 +50,26 @@ func New() telemetry.Logger {
 	return lg
 }
 
+// NewFlattened creates a new flattened logger for structured data.
+func NewFlattened() telemetry.Logger {
+	lg := &logger{
+		writer: os.Stdout,
+		now:    time.Now,
+	}
+	lg.Logger = function.NewLogger(lg.flattenedLog)
+	return lg
+}
+
 // NewUnstructured creates a new unstructured logger.
+// NOTE: This logger is not to be used for new development as it goes against
+// the contract of the telemetry.Logger interface. It expects Printf style data
+// from calls to Error, Info, and Debug. It has been added for converting legacy
+// code to use this new logging subsystem.
+//
+//	Example: log.Debug("values should be between %d and %d.", 12, 24)
+//
+// If you want to have a normal style log output but provide proper structured
+// data, please use the flattened logger by instantiating NewFlattened().
 func NewUnstructured() telemetry.Logger {
 	lg := &logger{
 		writer: os.Stdout,
@@ -155,4 +174,30 @@ func writeKeyValue(b *bytes.Buffer, args []interface{}, i, n int) {
 	} else {
 		_, _ = b.WriteString(fmt.Sprintf("%v", args[i+1]))
 	}
+}
+
+// flattenedLog emits the structured log as a flattened log at the given level
+func (l *logger) flattenedLog(level telemetry.Level, msg string, err error, values function.Values) {
+	var (
+		t   = l.now()
+		out bytes.Buffer
+	)
+
+	_, _ = out.WriteString(fmt.Sprintf("%d/%02d/%02d %02d:%02d:%02d  %-5v  %s",
+		t.Year(), int(t.Month()), t.Day(), t.Hour(), t.Minute(), t.Second(), level, msg))
+
+	if err != nil || len(values.FromContext) > 0 || len(values.FromLogger) > 0 || len(values.FromMethod) > 0 {
+		if err != nil {
+			_, _ = out.WriteString(fmt.Sprintf(" [error=%q", err.Error()))
+		} else {
+			_, _ = out.WriteString(" [")
+		}
+		writeArgs(&out, values.FromContext)
+		writeArgs(&out, values.FromLogger)
+		writeArgs(&out, values.FromMethod)
+		_, _ = out.WriteString("]")
+	}
+
+	_, _ = out.WriteString("\n")
+	_, _ = out.WriteTo(l.writer)
 }

--- a/logger.go
+++ b/logger.go
@@ -212,9 +212,8 @@ func (l *logger) flattenedLog(level telemetry.Level, msg string, err error, valu
 
 // writeArgs2 writes the collection of argument lists to the buffer.
 func writeArgs2(b *bytes.Buffer, args ...[]interface{}) {
-	t := len(args)
 	firstValue := true
-	for i := 0; i < t; i++ {
+	for i := 0; i < len(args); i++ {
 		n := len(args[i])
 		if n%2 == 1 {
 			args[i] = append(args[i], "(MISSING)")

--- a/logger_test.go
+++ b/logger_test.go
@@ -84,6 +84,68 @@ func TestLogger(t *testing.T) {
 	}
 }
 
+func TestFlattened(t *testing.T) {
+	tests := []struct {
+		name        string
+		level       telemetry.Level
+		logfunc     func(telemetry.Logger)
+		expected    *regexp.Regexp
+		metricCount float64
+	}{
+		{"none", telemetry.LevelNone, func(l telemetry.Logger) { l.Error("text", errors.New("error")) }, regexp.MustCompile("^$"), 1},
+		{"disabled-info", telemetry.LevelNone, func(l telemetry.Logger) { l.Info("text") }, regexp.MustCompile("^$"), 1},
+		{"disabled-debug", telemetry.LevelNone, func(l telemetry.Logger) { l.Debug("text") }, regexp.MustCompile("^$"), 0},
+		{"disabled-error", telemetry.LevelNone, func(l telemetry.Logger) { l.Error("text", errors.New("error")) }, regexp.MustCompile("^$"), 1},
+		{"info", telemetry.LevelInfo, func(l telemetry.Logger) { l.Info("text") },
+			matchFlattened(telemetry.LevelInfo, `text`, ``, ``), 1},
+		{"info-missing", telemetry.LevelInfo, func(l telemetry.Logger) { l.Info("text", "where") },
+			matchFlattened(telemetry.LevelInfo, `text`, `where="\(MISSING\)"`, ``), 1},
+		{"info-with-values", telemetry.LevelInfo, func(l telemetry.Logger) { l.Info("text", "where", "there", 1, "1") },
+			matchFlattened(telemetry.LevelInfo, `text`, `where="there"`, ``), 1},
+		{"error", telemetry.LevelInfo, func(l telemetry.Logger) { l.Error("text", errors.New("error")) },
+			matchFlattened(telemetry.LevelError, `text`, ``, `error`), 1},
+		{"error-missing", telemetry.LevelInfo, func(l telemetry.Logger) { l.Error("text", errors.New("error"), "where") },
+			matchFlattened(telemetry.LevelError, `text`, `where="\(MISSING\)"`, `error`), 1},
+		{"error-with-values", telemetry.LevelInfo, func(l telemetry.Logger) { l.Error("text", errors.New("error"), "where", "there", 1, "1") },
+			matchFlattened(telemetry.LevelError, `text`, `where="there"`, `error`), 1},
+		{"debug", telemetry.LevelDebug, func(l telemetry.Logger) { l.Debug("text") },
+			matchFlattened(telemetry.LevelDebug, `text`, ``, ``), 0},
+		{"debug-missing", telemetry.LevelDebug, func(l telemetry.Logger) { l.Debug("text", "where") },
+			matchFlattened(telemetry.LevelDebug, `text`, `where="\(MISSING\)"`, ``), 0},
+		{"debug-with-values", telemetry.LevelDebug, func(l telemetry.Logger) { l.Debug("text", "where", "there", 1, "1") },
+			matchFlattened(telemetry.LevelDebug, `text`, `where="there"`, ``), 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l := NewFlattened()
+
+			l.SetLevel(tt.level)
+			if l.Level() != tt.level {
+				t.Fatalf("loger.Level()=%s, want: %s", l.Level(), tt.level)
+			}
+
+			// Overwrite the output of the loggers to check the output messages
+			var out bytes.Buffer
+			l.(*logger).writer = &out
+
+			metric := mockMetric{}
+			ctx := telemetry.KeyValuesToContext(context.Background(), "ctx", "value")
+			l = l.Context(ctx).Metric(&metric).With().With(1, "").With("lvl", telemetry.LevelInfo).With("missing")
+
+			tt.logfunc(l)
+
+			str := out.String()
+			if !tt.expected.MatchString(str) {
+				t.Fatalf("expected %v to match %s", str, tt.expected)
+			}
+			if metric.count != tt.metricCount {
+				t.Fatalf("metric.count=%v, want %v", metric.count, tt.metricCount)
+			}
+		})
+	}
+}
+
 func TestUnstructured(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -224,6 +286,16 @@ const (
 
 func match(l telemetry.Level, keyvalues string) *regexp.Regexp {
 	return regexp.MustCompile(fmt.Sprintf("^time=%q level=%s msg=\"text\" ctx=\"value\" lvl=info missing=\"\\(MISSING\\)\"%s\\n$", rprefix, l, keyvalues))
+}
+
+func matchFlattened(l telemetry.Level, msg string, keys string, err string) *regexp.Regexp {
+	if keys != "" {
+		keys = " " + keys
+	}
+	if err != "" {
+		err = fmt.Sprintf("error=%q ", err)
+	}
+	return regexp.MustCompile(fmt.Sprintf("^%s  %-5v  %s \\[%sctx=\"value\" lvl=info missing=\"\\(MISSING\\)\"%s\\]\\n$", rprefix, l, msg, err, keys))
 }
 
 func matchUnstructured(l telemetry.Level, msg string) *regexp.Regexp {

--- a/logger_test.go
+++ b/logger_test.go
@@ -101,19 +101,19 @@ func TestFlattened(t *testing.T) {
 		{"info-missing", telemetry.LevelInfo, func(l telemetry.Logger) { l.Info("text", "where") },
 			matchFlattened(telemetry.LevelInfo, `text`, `where="\(MISSING\)"`, ``), 1},
 		{"info-with-values", telemetry.LevelInfo, func(l telemetry.Logger) { l.Info("text", "where", "there", 1, "1") },
-			matchFlattened(telemetry.LevelInfo, `text`, `where="there"`, ``), 1},
+			matchFlattened(telemetry.LevelInfo, `text`, `where="there" 1="1"`, ``), 1},
 		{"error", telemetry.LevelInfo, func(l telemetry.Logger) { l.Error("text", errors.New("error")) },
 			matchFlattened(telemetry.LevelError, `text`, ``, `error`), 1},
 		{"error-missing", telemetry.LevelInfo, func(l telemetry.Logger) { l.Error("text", errors.New("error"), "where") },
 			matchFlattened(telemetry.LevelError, `text`, `where="\(MISSING\)"`, `error`), 1},
 		{"error-with-values", telemetry.LevelInfo, func(l telemetry.Logger) { l.Error("text", errors.New("error"), "where", "there", 1, "1") },
-			matchFlattened(telemetry.LevelError, `text`, `where="there"`, `error`), 1},
+			matchFlattened(telemetry.LevelError, `text`, `where="there" 1="1"`, `error`), 1},
 		{"debug", telemetry.LevelDebug, func(l telemetry.Logger) { l.Debug("text") },
 			matchFlattened(telemetry.LevelDebug, `text`, ``, ``), 0},
 		{"debug-missing", telemetry.LevelDebug, func(l telemetry.Logger) { l.Debug("text", "where") },
 			matchFlattened(telemetry.LevelDebug, `text`, `where="\(MISSING\)"`, ``), 0},
 		{"debug-with-values", telemetry.LevelDebug, func(l telemetry.Logger) { l.Debug("text", "where", "there", 1, "1") },
-			matchFlattened(telemetry.LevelDebug, `text`, `where="there"`, ``), 0},
+			matchFlattened(telemetry.LevelDebug, `text`, `where="there" 1="1"`, ``), 0},
 	}
 
 	for _, tt := range tests {
@@ -251,6 +251,31 @@ func BenchmarkUnstructuredLog15Args(b *testing.B) {
 func BenchmarkUnstructuredLog30Args(b *testing.B) {
 	l := New().(*logger)
 	benchmarkLogger(b, 10, l, l.unstructuredLog)
+}
+
+func BenchmarkFlattenedLog0Args(b *testing.B) {
+	l := New().(*logger)
+	benchmarkLogger(b, 0, l, l.flattenedLog)
+}
+
+func BenchmarkFlattenedLog3Args(b *testing.B) {
+	l := New().(*logger)
+	benchmarkLogger(b, 1, l, l.flattenedLog)
+}
+
+func BenchmarkFlattenedLog9Args(b *testing.B) {
+	l := New().(*logger)
+	benchmarkLogger(b, 3, l, l.flattenedLog)
+}
+
+func BenchmarkFlattenedLog15Args(b *testing.B) {
+	l := New().(*logger)
+	benchmarkLogger(b, 5, l, l.flattenedLog)
+}
+
+func BenchmarkFlattenedLog30Args(b *testing.B) {
+	l := New().(*logger)
+	benchmarkLogger(b, 10, l, l.flattenedLog)
 }
 
 func benchmarkLogger(b *testing.B, nargs int, l *logger, logFunc function.Emit) {


### PR DESCRIPTION
This adds a hybrid structured/unstructured output logger implementation for telemetry.Logger. 

## Context
`telemetry.Logger` is an abstract interface that expects structured data input (there are no `Errorf`, `Infof`, and `Debugf` style methods). Since `telemetry.Logger` has replaced a huge amount of unstructured log lines, the `NewUnstructured` Logger was created for the transition period. It assumes that variadic arguments are passed to `Error`, `Info`, and `Debug` where the main msg argument is a Printf style format string.  This provides incorrect output if telemetry.Logger interface is properly using structured data.

Example:
```go
    strLen := 12

    // using printf style data:
    logger.Info("we received a string of size %d", strLen)
    // Output: 2023/08/05 23:55:50  info   we received a string of size 12

    // using the logging interface correctly:
    logger.Info("we received a string", "size", stLen)
    // Output: 2023/08/05 23:55:50  info   we received a string%!(EXTRA string=size, int=12)
```

For structured data the `New` (structured) logger was created, which provides fully structured data.

Example:
```go
    logger.Info("we received a string", "size", strLen)
    // Output: time="2023/08/05 23:55:50" level=info msg="we received a string" size=12
```

The ` NewFlattened` logger provides a middle ground where the log line is partially unstructured except for key value pairs provided through `Context`, `With()`, as well as the key-value arguments from the `Debug`, `Info`, and `Error` messages. Attached errors are also rolled up in the structured section. This makes this new logger implementation ideally suited for usage in applications which packages have been instrumented with structured data while desiring a better human readable flattened log output.

Example:
```go
  logger.With("method", "order").Error("unable to retrieve product", err, "product", "TSB")
  // Output: 2023/08/05 23:55:50  error  unable to retrieve product [error="database connection timed out" method="order" product="TSB"]

```